### PR TITLE
Added a mixin improving EnderIO's Round Robin functionality

### DIFF
--- a/mod/build.gradle
+++ b/mod/build.gradle
@@ -32,13 +32,13 @@ dependencies {
 	
 	deobfCompile("curse.maven:ActuallyAdditions-228404:3117927")
 //	deobfProvided("curse.maven:DraconicEvolution-223565:3431261")
-//	deobfProvided(
-//			"curse.maven:EnderIO-64578:3328811",
-//			"curse.maven:ProjectIntelligence-306028:2833640",
-//			"curse.maven:EnderCore-231868:2972849",
-//			"curse.maven:BrandonsCore-231382:3408276",
-//			"curse.maven:CodeChickenLib-242818:2779848"
-//	)
+	deobfProvided(
+			"curse.maven:EnderIO-64578:3328811",
+			//"curse.maven:ProjectIntelligence-306028:2833640",
+			"curse.maven:EnderCore-231868:2972849",
+			//"curse.maven:BrandonsCore-231382:3408276",
+			"curse.maven:CodeChickenLib-242818:2779848"
+	)
 //	compile "cofh:RedstoneFlux:1.12-2.0.0.1:universal"
 	
 	deobfProvided("curse.maven:Erebus-220698:3211974")

--- a/mod/src/main/java/btpos/dj2addons/patches/mixin/enderio/MNetworkedInventory.java
+++ b/mod/src/main/java/btpos/dj2addons/patches/mixin/enderio/MNetworkedInventory.java
@@ -1,0 +1,33 @@
+package btpos.dj2addons.patches.mixin.enderio;
+
+import crazypants.enderio.conduits.conduit.item.NetworkedInventory;
+
+import javax.annotation.Nonnull;
+import net.minecraft.util.EnumFacing;
+import crazypants.enderio.conduits.conduit.item.IItemConduit;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+import org.spongepowered.asm.mixin.injection.callback.LocalCapture;
+import net.minecraftforge.items.IItemHandler;
+import crazypants.enderio.base.filter.item.IItemFilter;
+
+@Mixin(value=NetworkedInventory.class, remap=false)
+public abstract class MNetworkedInventory {
+	@Shadow
+	private @Nonnull IItemConduit con;
+	@Shadow
+	private @Nonnull EnumFacing conDir;
+	@Shadow
+	private void setNextStartingSlot(int slot) {}
+
+	@Inject(method = "transferItems", at = @At(value = "RETURN", ordinal = 2), locals = LocalCapture.CAPTURE_FAILSOFT)
+	public void onTransferItems(CallbackInfoReturnable<Boolean> ci,
+		IItemHandler inventory, int numSlots, int maxExtracted, IItemFilter filter, int slotChecksPerTick, int i, int slot	
+		) {
+		if (!con.isRoundRobinEnabled(conDir)) return;
+		setNextStartingSlot(slot + 1);
+	}
+}

--- a/mod/src/main/resources/mixins.dj2addons.def.patches.json
+++ b/mod/src/main/resources/mixins.dj2addons.def.patches.json
@@ -12,7 +12,8 @@
     "modularmagic.MRequirementLifeEssence",
     "moretweaker.MInputs",
     "packagedauto.MMiscUtil",
-    "rftools.MNBTMatchingRecipe"
+    "rftools.MNBTMatchingRecipe",
+    "enderio.MNetworkedInventory"
   ],
   "client": [
     "immersiveengineering.MTileEntityMultiblockPart",


### PR DESCRIPTION
Hi! I don't know if this "fix" belongs here or not since it's not obviously this is a bugfix, but it just improves the player experience in dj2 a lot (example: don't have to set 6 extraction points with 6 filters to automate 1 alchemy table).

But yeah, this is commonly known as "conduit patch". It makes the conduit cycle to the next slot (as well as next machine as usual) when round robin is used. I've been playing with it for a few months (as well as some other players) and think it's stable enough for the pack :yay: