### PR TITLE
Also override `isDummy` on all other ImmersiveEngineering Machines

### DIFF
--- a/src/main/java/btpos/dj2addons/patches/mixin/immersiveengineering/MTileEntityMultiblockPartSubclasses.java
+++ b/src/main/java/btpos/dj2addons/patches/mixin/immersiveengineering/MTileEntityMultiblockPartSubclasses.java
@@ -4,6 +4,7 @@ import blusunrize.immersiveengineering.common.blocks.TileEntityMultiblockPart;
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityAlloySmelter;
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityBlastFurnace;
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityCokeOven;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityExcavator;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -12,7 +13,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(value={
 		TileEntityAlloySmelter.class,
 		TileEntityBlastFurnace.class,
-		TileEntityCokeOven.class
+		TileEntityCokeOven.class,
+		TileEntityExcavator.class
 }, remap=false)
 public abstract class MTileEntityMultiblockPartSubclasses<T extends TileEntityMultiblockPart<T>> extends TileEntityMultiblockPart<T> {
 	protected MTileEntityMultiblockPartSubclasses(int[] structureDimensions) {

--- a/src/main/java/btpos/dj2addons/patches/mixin/immersiveengineering/MTileEntityMultiblockPartSubclasses.java
+++ b/src/main/java/btpos/dj2addons/patches/mixin/immersiveengineering/MTileEntityMultiblockPartSubclasses.java
@@ -5,6 +5,7 @@ import blusunrize.immersiveengineering.common.blocks.stone.TileEntityAlloySmelte
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityBlastFurnace;
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityCokeOven;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityExcavator;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityArcFurnace;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,7 +15,8 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 		TileEntityAlloySmelter.class,
 		TileEntityBlastFurnace.class,
 		TileEntityCokeOven.class,
-		TileEntityExcavator.class
+		TileEntityExcavator.class,
+		TileEntityArcFurnace.class
 }, remap=false)
 public abstract class MTileEntityMultiblockPartSubclasses<T extends TileEntityMultiblockPart<T>> extends TileEntityMultiblockPart<T> {
 	protected MTileEntityMultiblockPartSubclasses(int[] structureDimensions) {

--- a/src/main/java/btpos/dj2addons/patches/mixin/immersiveengineering/MTileEntityMultiblockPartSubclasses.java
+++ b/src/main/java/btpos/dj2addons/patches/mixin/immersiveengineering/MTileEntityMultiblockPartSubclasses.java
@@ -3,9 +3,26 @@ package btpos.dj2addons.patches.mixin.immersiveengineering;
 import blusunrize.immersiveengineering.common.blocks.TileEntityMultiblockPart;
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityAlloySmelter;
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityBlastFurnace;
+import blusunrize.immersiveengineering.common.blocks.stone.TileEntityBlastFurnaceAdvanced;
 import blusunrize.immersiveengineering.common.blocks.stone.TileEntityCokeOven;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityExcavator;
 import blusunrize.immersiveengineering.common.blocks.metal.TileEntityArcFurnace;
+
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityMultiblockMetal;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityAssembler;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityAutoWorkbench;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityBottlingMachine;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityCrusher;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityDieselGenerator;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityFermenter;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityLightningrod;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityMetalPress;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityMixer;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntityRefinery;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntitySheetmetalTank;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntitySilo;
+import blusunrize.immersiveengineering.common.blocks.metal.TileEntitySqueezer;
+
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -14,9 +31,25 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 @Mixin(value={
 		TileEntityAlloySmelter.class,
 		TileEntityBlastFurnace.class,
+		TileEntityBlastFurnaceAdvanced.class,
 		TileEntityCokeOven.class,
 		TileEntityExcavator.class,
-		TileEntityArcFurnace.class
+		TileEntityArcFurnace.class,
+		
+		TileEntityMultiblockMetal.class,
+		TileEntityAssembler.class,
+		TileEntityAutoWorkbench.class,
+		TileEntityBottlingMachine.class,
+		TileEntityCrusher.class,
+		TileEntityDieselGenerator.class,
+		TileEntityFermenter.class,
+		TileEntityLightningrod.class,
+		TileEntityMetalPress.class,
+		TileEntityMixer.class,
+		TileEntityRefinery.class,
+		TileEntitySheetmetalTank.class,
+		TileEntitySilo.class,
+		TileEntitySqueezer.class
 }, remap=false)
 public abstract class MTileEntityMultiblockPartSubclasses<T extends TileEntityMultiblockPart<T>> extends TileEntityMultiblockPart<T> {
 	protected MTileEntityMultiblockPartSubclasses(int[] structureDimensions) {


### PR DESCRIPTION
I noticed that people were still crashing from the `isDummy` method.
Apparently the Excavator was missed.

Ref. #8 

Please note, that I have not tested compilation (this fix was made entirely in github's editor). It should nonetheless work and compile.